### PR TITLE
Update black version to 22.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-black==20.8b1
+black==22.3.0
 django==3.1.3
 flake8==3.8.4
 isort==5.6.4


### PR DESCRIPTION
Upgrading to latest version, when trying to install the black==20.8b1 package in python 3.8 I got the following error:
![erro_black_install](https://user-images.githubusercontent.com/7028769/165324737-aab63726-0b49-45e1-8bc3-b3f040874cab.png)


After some research I came across this discourse (https://github.com/psf/black/issues/1847) where I saw that it would be better to update the black version to the latest one where we have support up to python 3.10